### PR TITLE
Replace deprecated 'intllib.Getter' with 'intllib.make_gettext_pair'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,11 @@ dofancy = false
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
 if minetest.global_exists('intllib') then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		S = intllib.make_gettext_pair()
+	else
+		S = intllib.Getter()
+	end
 else
 	S = function(s) return s end
 end


### PR DESCRIPTION
Checks if *intllib.make_gettext_pair* available, otherwise uses older *intllib.Getter*.